### PR TITLE
ngx luarocks

### DIFF
--- a/Formula/ngx_luarocks.rb
+++ b/Formula/ngx_luarocks.rb
@@ -1,0 +1,31 @@
+require 'formula'
+
+class NgxLuarocks < Formula
+  homepage 'https://rocks.moonscript.org/'
+
+  stable do
+    url 'http://keplerproject.github.io/luarocks/releases/luarocks-2.2.1.tar.gz'
+    sha1 '82b858889e31ec0eb4d05ce7ea3a72fdf5403aad'
+  end
+
+  depends_on 'ngx_openresty'
+
+  def install
+    ngx_openresty = Formula['ngx_openresty']
+
+    args = [
+      "--prefix=#{prefix}",
+      "--lua-version=5.1",
+      "--lua-suffix=jit-2.1.0-alpha",
+      "--with-lua=#{ngx_openresty.prefix}/luajit",
+      "--with-lua-include=#{ngx_openresty.prefix}/luajit/include/luajit-2.1",
+      "--with-lua-lib=#{ngx_openresty.prefix}/lualib"
+    ]
+    
+    system "./configure", *args
+
+    system "make build"
+    system "make install"
+  end
+end
+


### PR DESCRIPTION
Adds Formula for 'ngx_luarocks'.

Homebrew's luarocks now depend on Lua 5.2/3.

This adds a luarocks, that is using openresty's luajit, so 
all the rocks you install, are compiled with luajit in mind 
and shall be available in openresty.

See `luarocks path`

```
export LUA_PATH='/Users/mikz/.luarocks/share/lua/5.1/?.lua;/Users/mikz/.luarocks/share/lua/5.1/?/init.lua;/usr/local/Cellar/ngx_luarocks/2.2.1/share/lua/5.1/?.lua;/usr/local/Cellar/ngx_luarocks/2.2.1/share/lua/5.1/?/init.lua;./?.lua;/usr/local/Cellar/ngx_openresty/1.7.10.1/luajit/share/luajit-2.1.0-alpha/?.lua;/usr/local/share/lua/5.1/?.lua;/usr/local/share/lua/5.1/?/init.lua;/usr/local/Cellar/ngx_openresty/1.7.10.1/luajit/share/lua/5.1/?.lua;/usr/local/Cellar/ngx_openresty/1.7.10.1/luajit/share/lua/5.1/?/init.lua'
export LUA_CPATH='/Users/mikz/.luarocks/lib/lua/5.1/?.so;/usr/local/Cellar/ngx_luarocks/2.2.1/lib/lua/5.1/?.so;./?.so;/usr/local/lib/lua/5.1/?.so;/usr/local/Cellar/ngx_openresty/1.7.10.1/luajit/lib/lua/5.1/?.so;/usr/local/lib/lua/5.1/loadall.so'
```
